### PR TITLE
Add PHAR and self-update support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+bin
 vendor
 composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
   - hhvm
 
 before_script:
+  - composer self-update
   - composer install
 
-script: vendor/bin/phpunit
+script: bin/phpunit

--- a/box.json
+++ b/box.json
@@ -1,0 +1,24 @@
+{
+    "chmod": "0755",
+    "directories": [ "src" ],
+    "files": [ "vendor/herrera-io/phar-update/res/schema.json" ],
+    "finder": [
+        {
+            "name": "*.php",
+            "exclude": [
+              "Tests",
+              "tests",
+              "phpunit",
+              "sebastian",
+              "phpspec",
+              "doctrine",
+              "phpdocumentor"
+            ],
+            "in": "vendor"
+        }
+    ],
+    "git-version": "package_version",
+    "main": "./conductor",
+    "output": "./dist/conductor-@git-version@.phar",
+    "stub": true
+}

--- a/build-version
+++ b/build-version
@@ -1,0 +1,53 @@
+#!/usr/bin/env php
+<?php
+
+$distDir = __DIR__ . '/dist';
+$releaseDir = __DIR__ . '/../conductor-release';
+$releaseUrl = 'http://mybuilder.github.io/conductor/release/';
+$releaseBranch = 'gh-pages';
+$repository = 'git@github.com:mybuilder/conductor.git';
+
+// --
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+function execute($cmd)
+{
+    echo "- $cmd\n";
+    system($cmd);
+}
+
+$config = new KevinGH\Box\Configuration('', '');
+$newVersion = $config->getGitVersion();
+$newRelease = "conductor-$newVersion.phar";
+
+echo "Have you made a new tag release for this version? ";
+if ('y' !== strtolower(trim(fgets(STDIN)))) {
+    exit;
+}
+
+echo "Build\n";
+execute(__DIR__ . '/bin/box build');
+echo "\n";
+
+echo "Clone\n";
+execute("rm -rf $releaseDir");
+execute("git clone -b $releaseBranch --single-branch $repository $releaseDir");
+$releaseDir = realpath($releaseDir);
+echo "\n";
+
+echo "Copy\n";
+execute("cp $distDir/$newRelease $releaseDir/release/$newRelease");
+
+echo "Manifest\n";
+$manifests = is_file("$releaseDir/manifest.json")
+    ? json_decode(file_get_contents("$releaseDir/manifest.json"), true)
+    : array();
+$manifests[] = array(
+    'name' => $newRelease,
+    'sha1' => sha1_file("$distDir/$newRelease"),
+    'url' => "$releaseUrl/$newRelease",
+    'version' => $newVersion
+);
+file_put_contents("$releaseDir/manifest.json", json_encode($manifests, JSON_PRETTY_PRINT));
+echo "Writing... $releaseDir/manifest.json\n";

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,16 @@
         "symfony/filesystem": "~2.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.5"
+        "phpunit/phpunit": "~4.5",
+        "kherge/box": "~2.5"
     },
     "autoload": {
         "psr-4": {
             "MyBuilder\\Conductor\\": "src/"
         }
+    },
+    "config": {
+        "bin-dir": "bin"
     },
     "bin": ["conductor"],
     "extra": {

--- a/conductor
+++ b/conductor
@@ -14,8 +14,9 @@ use MyBuilder\Conductor\Conductor;
 
 $conductor = new Conductor(new Filesystem());
 
-$app = new Application();
+$app = new Application('Conductor', '@package_version@');
 $app->add(new Commands\UpdateCommand($conductor));
 $app->add(new Commands\SymlinkCommand($conductor));
 $app->add(new Commands\LockFixerCommand($conductor));
+$app->add(new Commands\SelfUpdateCommand);
 $app->run();

--- a/dist/.gitignore
+++ b/dist/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/src/Command/SelfUpdateCommand.php
+++ b/src/Command/SelfUpdateCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace MyBuilder\Conductor\Command;
+
+use Herrera\Phar\Update\Manager;
+use Herrera\Phar\Update\Manifest;
+use Herrera\Version\Parser;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SelfUpdateCommand extends Command
+{
+    const MANIFEST_FILE = 'http://mybuilder.github.io/conductor/manifest.json';
+
+    protected function configure()
+    {
+        $this
+            ->setName('self-update')
+            ->setAliases(array('selfupdate'))
+            ->setDescription('Updates conductor.phar to the latest version.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $manifest = Manifest::loadFile(self::MANIFEST_FILE);
+        $version = Parser::toVersion($this->getApplication()->getVersion());
+
+        if ($update = $manifest->findRecent($version)) {
+            $output->write(
+                sprintf(
+                    '<info>Updating conductor.phar from %s -> %s... </info>',
+                    $version,
+                    $update->getVersion()
+                )
+            );
+
+            $manager = new Manager($manifest);
+            if ($manager->update($version)) {
+                $output->writeln("<info>Complete</info>");
+            }
+        } else {
+            $output->writeln("<info>Currently running the latest conductor.phar: $version</info>");
+        }
+    }
+}


### PR DESCRIPTION
Adds the ability to build PHAR build releases based on the current Git Tag (i.e. 1.0.1).
The build script assumes you wish to distribute releases using this repos gh-pages branch.

Example usage for new release:

``` bash
$ git tag 1.0.5
$ ./build-version
$ cd ../conductor-release
$ git add .
$ git commit -m '1.0.5'
$ git push origin gh-pages
```
