### PR TITLE
Create a `copy` command

### DIFF
--- a/conductor
+++ b/conductor
@@ -17,5 +17,6 @@ $conductor = new Conductor(new Filesystem());
 $app = new Application();
 $app->add(new Commands\UpdateCommand($conductor));
 $app->add(new Commands\SymlinkCommand($conductor));
+$app->add(new Commands\CopyCommand($conductor));
 $app->add(new Commands\LockFixerCommand($conductor));
 $app->run();

--- a/src/Command/CopyCommand.php
+++ b/src/Command/CopyCommand.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace MyBuilder\Conductor\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CopyCommand extends BaseCommand
+{
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName("copy")
+            ->setDescription('Copy internal packages to vendors');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('<info>Copying packages</info>');
+
+        $this->conductor->copyPackages(getcwd());
+    }
+}

--- a/src/Conductor.php
+++ b/src/Conductor.php
@@ -40,6 +40,16 @@ class Conductor
         }
     }
 
+    public function copyPackages($rootPath)
+    {
+        $finder = new Finder();
+        $finder->files()->name('replace_with_symlink.path');
+
+        foreach ($finder->in($rootPath) as $file) {
+            $this->copyPackageToVendor(file_get_contents($file), dirname($file));
+        }
+    }
+
     private function symlinkPackageToVendor($packagePath, $vendorPath)
     {
         $relative = $this->fileSystem->makePathRelative(realpath($packagePath), realpath($vendorPath . '/../'));
@@ -47,5 +57,19 @@ class Conductor
         $this->fileSystem->rename($vendorPath, $vendorPath . '_linked', true);
         $this->fileSystem->symlink($relative, $vendorPath);
         $this->fileSystem->remove($vendorPath . '_linked');
+    }
+
+    private function copyPackageToVendor($packagePath, $vendorPath)
+    {
+        $directoryIterator = new \RecursiveDirectoryIterator($packagePath, \RecursiveDirectoryIterator::SKIP_DOTS);
+        $iterator = new \RecursiveIteratorIterator($directoryIterator, \RecursiveIteratorIterator::SELF_FIRST);
+
+        foreach ($iterator as $item) {
+            if ($item->isDir()) {
+                $this->fileSystem->mkdir($vendorPath . DIRECTORY_SEPARATOR . $iterator->getSubPathName());
+            } else {
+                $this->fileSystem->copy($item, $vendorPath . DIRECTORY_SEPARATOR . $iterator->getSubPathName());
+            }
+        }
     }
 }


### PR DESCRIPTION
On some architectures, symlinking won't work as expected and we need a fallback. That's why this `copy` command that, instead of symlinking... copy :)
